### PR TITLE
chore/general cleanup and rewrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .PHONY: all
 
-all: go-hello.so go-log.so
+all: go-hello go-hello-lm.so go-log
 
-go-hello.so: go-hello.go
-	go build -buildmode=plugin go-hello.go
+go-hello: go-hello.go
+	go build go-hello.go
 
-go-log.so: go-log.go
-	go build -buildmode=plugin go-log.go
+go-hello-lm.so: go-hello-lm.go
+	go build -buildmode=plugin go-hello-lm.go
+
+go-log: go-log.go
+	go build go-log.go

--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@ small examples to get you started writing your own:
 
 * **go-hello**: a "hello world" plugin, which reads a request header
   and sets a response header.
+* **go-hello-lm**: same as the previous as a loadble module to use
+  with the go-pluginserver.
 * **go-log**: a reimplementation of Kong's `file-log` plugin in Go.
+  shows the use of go I/O, goroutines and long-lived globals.

--- a/go-hello-lm.go
+++ b/go-hello-lm.go
@@ -10,12 +10,7 @@ import (
 	"log"
 
 	"github.com/Kong/go-pdk"
-	"github.com/Kong/go-pdk/server"
 )
-
-func main() {
-	server.StartServer(New, Version, Priority)
-}
 
 var Version = "0.2"
 var Priority = 1

--- a/go-log.go
+++ b/go-log.go
@@ -1,73 +1,158 @@
 /*
-A reimplementation of Kong's file-log plugin in Go.
+	A reimplementation of Kong's file-log plugin in Go.
+
+	Here we use goroutines to detach execution from the
+	request/response cycle.
+
+	Global variables are also long-lived, and use Mutex
+	locks to protect maps from being modified by
+	concurrent execution.
 */
+
 package main
 
 import (
-	"github.com/Kong/go-pdk"
+	"log"
 	"os"
+	"sync"
+
+	"github.com/Kong/go-pdk"
+	"github.com/Kong/go-pdk/server"
 )
+
+// Start the embedded server
+// Note that the parameters are just values, there's no
+// need to give them exported names as required by
+// the go-pluginserver.  Even the `New()` constructor
+// function can be written inline.  (if it's more readable
+// or not is up for debate)
+func main() {
+	server.StartServer(func() interface{} {
+		return &Config{}
+	}, "0.3", 2)
+}
 
 type Config struct {
 	Path   string
 	Reopen bool
 }
 
+// Global variables have the same lifespan
+// as the service process.  No need
+// to use any persistence to pass them
+// from one event to another.
+// Still, note that the service can be
+// killed and respawned at any moment.
+// Use some kind of external storage
+// to save any state that must survive.
 var fileDescriptors map[string]*os.File
 var channels map[string]chan []byte
 
-func New() interface{} {
-	return &Config{}
-}
+// multiple events can be handled concurrently
+// global mutable maps (like those above) should
+// be protected with locks
+var fdmap_lock sync.Mutex
+var chmap_lock sync.Mutex
 
 func (conf Config) Log(kong *pdk.PDK) {
+	ch, is_new := getChannel(conf.Path)
+	if is_new {
+		// this is where it "escapes" the event cycle
+		go conf.collect(ch)
+	}
+
+	msg, err := kong.Log.Serialize()
+	if err != nil {
+		log.Print(err.Error())
+		return
+	}
+
+	ch <- []byte(msg)
+}
+
+// get the channel associated with
+// the file in the config.
+func getChannel(path string) (chan []byte, bool) {
+	chmap_lock.Lock()
+	defer chmap_lock.Unlock()
+
+	var is_new = false
+
 	if channels == nil {
 		channels = make(map[string]chan []byte)
 	}
 
-	ch, ok := channels[conf.Path]
+	ch, ok := channels[path]
 	if !ok {
-		channels[conf.Path] = make(chan []byte)
-		ch = channels[conf.Path]
-
-		go func() {
-			for {
-				b := <-ch
-
-				if fileDescriptors == nil {
-					fileDescriptors = make(map[string]*os.File)
-				}
-
-				fd, ok := fileDescriptors[conf.Path]
-				if ok {
-					if conf.Reopen {
-						fd.Close()
-						delete(fileDescriptors, conf.Path)
-						ok = false
-					}
-				}
-
-				if !ok {
-					var err error
-					fd, err = os.OpenFile(conf.Path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
-					if err != nil {
-						kong.Log.Err("failed to open the file: ", err.Error())
-						return
-					}
-					fileDescriptors[conf.Path] = fd
-				}
-
-				fd.Write(b)
-				fd.Write([]byte("\n"))
-			}
-		}()
-
+		channels[path] = make(chan []byte)
+		is_new = true
+		ch = channels[path]
 	}
 
-	log, err := kong.Log.Serialize()
-	if err != nil {
-		kong.Log.Err(err.Error())
+	return ch, is_new
+}
+
+//
+// code below this line works "outside" Kong events and should not use the PDK
+// --------------------------------
+//
+
+// Log collection
+//
+// Note that the goroutine that calls this function will
+// persist for several Kong events so it can't use
+// any PDK function.  The easiest way to enforce this
+// is to factor the 'long lived' code in a function
+// like this and *not* pass the `kong` variable.
+//
+// Here the `conf` object is the one passed from
+// the event that spawned the goroutine.  It will
+// not be updated on new events.
+func (conf Config) collect(ch chan []byte) {
+	for {
+		b := <-ch
+
+		fd, ok := conf.getFileDesc()
+		if !ok {
+			return
+		}
+
+		fd.Write(b)
+		fd.Write([]byte("\n"))
+	}
+}
+
+// get an open descriptor for the logfile.
+//
+// this is called on each new event to give
+// the opportunity to close and reopen if
+// requested by the configuration.
+func (conf Config) getFileDesc() (*os.File, bool) {
+	fdmap_lock.Lock()
+	defer fdmap_lock.Unlock()
+
+	if fileDescriptors == nil {
+		fileDescriptors = make(map[string]*os.File)
 	}
 
-	ch <- []byte(log)
+	fd, ok := fileDescriptors[conf.Path]
+	if ok {
+		if conf.Reopen {
+			fd.Close()
+			delete(fileDescriptors, conf.Path)
+			ok = false
+		}
+	}
+
+	if !ok {
+		var err error
+		fd, err = os.OpenFile(conf.Path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			log.Printf("failed to open the file: %s", err.Error())
+			return nil, false
+		}
+		fileDescriptors[conf.Path] = fd
+	}
+
+	return fd, true
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Kong/go-plugins
 
 go 1.13
 
-require github.com/Kong/go-pdk v0.6.0
+require github.com/Kong/go-pdk v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Kong/go-pdk v0.6.0 h1:KZZKGYK5NbTIMQa5P1IRldMvA5/LJEoHhrsOQlVCPHo=
-github.com/Kong/go-pdk v0.6.0/go.mod h1:SrAne3YN4a7pNrlJ6Fb6xwa6kOhV2vDY/mqpb3X0fs4=
+github.com/Kong/go-pdk v0.6.1 h1:L0zZXyPnWzuGhaUOtoAiDV3V+KfnuMqlF//g5oISPkE=
+github.com/Kong/go-pdk v0.6.1/go.mod h1:SrAne3YN4a7pNrlJ6Fb6xwa6kOhV2vDY/mqpb3X0fs4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -7,7 +7,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/ugorji/go v1.2.1 h1:dz+JxTe7GZQdErTo7SREc1jQj/hFP1k7jyIAwODoW+k=
 github.com/ugorji/go v1.2.1/go.mod h1:cSVypSfTLm2o9fKxXvQgn3rMmkPXovcWor6Qn5tbFmI=
+github.com/ugorji/go/codec v1.2.1 h1:/TRfW3XKkvWvmAYyCUaQlhoCDGjcvNR8xVVA/l5p/jQ=
 github.com/ugorji/go/codec v1.2.1/go.mod h1:s/WxCRi46t8rA+fowL40EnmD7ec0XhR7ZypxeBNdzsM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
General themes:
- Embedded server by default.  Only `go-hello-lm.go` is for the pluginserver.
- Use of Go native log.
- Lots of explanation docs in the `go-log` example, emphasizing how goroutines can be "detached" and if so, they shouldn't use the PDK.